### PR TITLE
+ [html5] input and textarea enter key type

### DIFF
--- a/examples/component/input-demo.we
+++ b/examples/component/input-demo.we
@@ -93,6 +93,28 @@
                         id="input1"
                 />
             </wxc-panel>
+            <wxc-panel title="input keybord event type" type="primary">
+                  <input
+                          type="text"
+                          placeholder="search..."
+                          class="input"
+                          value=""
+                          id="search-input"
+                          return-key-type="next"
+                          onreturn="return"
+                  />
+            </wxc-panel>
+            <wxc-panel title="input keybord event type" type="primary">
+                  <textarea
+                          type="text"
+                          placeholder="search..."
+                          class="input"
+                          value=""
+                          id="search-textarea"
+                          return-key-type="next"
+                          onreturn="return"
+                  />
+            </wxc-panel>
         </scroller>
     </div>
 </template>
@@ -133,6 +155,9 @@
             },
             blur: function () {
                 this.$el('input1').blur();
+            },
+            return: function(event) {
+                console.log('onreturn', event.returnKeyType);
             }
         }
     };

--- a/examples/component/input-demo.we
+++ b/examples/component/input-demo.we
@@ -104,17 +104,6 @@
                           onreturn="return"
                   />
             </wxc-panel>
-            <wxc-panel title="input keybord event type" type="primary">
-                  <textarea
-                          type="text"
-                          placeholder="search..."
-                          class="input"
-                          value=""
-                          id="search-textarea"
-                          return-key-type="next"
-                          onreturn="return"
-                  />
-            </wxc-panel>
         </scroller>
     </div>
 </template>

--- a/examples/vue/components/input.vue
+++ b/examples/vue/components/input.vue
@@ -28,7 +28,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .input {
     font-size: 60px;
     height: 80px;

--- a/examples/vue/components/textarea.vue
+++ b/examples/vue/components/textarea.vue
@@ -17,7 +17,7 @@
   </scroller>
 </template>
 
-<style>
+<style scoped>
   .textarea {
     font-size: 30px;
     height: 280px;

--- a/examples/vue/components/textarea.vue
+++ b/examples/vue/components/textarea.vue
@@ -1,38 +1,29 @@
 <template>
   <scroller>
-    <panel title="input" type="primary">
-      <input
-        type="text"
-        placeholder="Text Input"
-        class="input"
+    <panel title="textarea" type="primary">
+      <textarea
+        class="textarea"
         autofocus="true"
-        value=""
+        return-key-type="done"
+        @return="onreturn"
         @change="onchange"
         @input="oninput"
       />
       <text>oninput: {{txtInput}}</text>
       <text>onchange: {{txtChange}}</text>
-    </panel>
-    <panel title="test input enter key type" type="primary">
-      <input
-        type="text"
-        placeholder="search ..."
-        class="input"
-        autofocus="true"
-        return-key-type="search"
-        @return="onreturn"
-      />
       <text>enter key type: {{returnType}}</text>
-      <text>Action: {{msg}}</text>
+      <text>action: {{msg}}</text>
     </panel>
   </scroller>
 </template>
 
 <style>
-  .input {
-    font-size: 60px;
-    height: 80px;
+  .textarea {
+    font-size: 30px;
+    height: 280px;
     width: 400px;
+    border-width: 2px;
+    border-color: #ccc;
   }
 </style>
 
@@ -53,21 +44,13 @@
     methods: {
       onchange: function(event) {
         this.txtChange = event.value;
-        modal.toast({
-          message: 'onchange: ' + event.value,
-          duration: 2
-        })
       },
       oninput: function(event) {
         this.txtInput = event.value;
-        modal.toast({
-          message: 'onitput: ' + event.value,
-          duration: 1
-        })
       },
       onreturn: function(event) {
         this.returnType = event.returnKeyType;
-        this.msg = 'You are ' + this.returnType + ' ' + event.value;
+        this.msg = 'You are "' + this.returnType + '" ' + event.value;
       }
     }
   };

--- a/html5/render/browser/extend/components/input.js
+++ b/html5/render/browser/extend/components/input.js
@@ -1,4 +1,5 @@
 'use strict'
+import { findEnterKeyType } from '../../utils/index'
 
 let appendStyle
 
@@ -34,7 +35,25 @@ const proto = {
     node.classList.add(this.className)
     node.classList.add('weex-element')
     this.placeholder && (node.placeholder = this.placeholder)
+    this.createKeybordEvent(node)
     return node
+  },
+
+  // support enter key envent
+  createKeybordEvent (node) {
+    if (Array.isArray(this.data.event) && this.data.event.indexOf('return') > -1) {
+      node.addEventListener('keyup', (ev) => {
+        const code = ev.keyCode
+        let key = ev.key
+        if (code === 13) {
+          if (key.toLowerCase() === 'tab') {
+            key = 'next'
+          }
+          const rightKeyType = findEnterKeyType(this.data.attr['returnKeyType'])
+          this.dispatchEvent('return', { returnKeyType: rightKeyType })
+        }
+      }, false)
+    }
   },
 
   focus () {
@@ -68,6 +87,10 @@ const attr = {
     this.node.type = availableTypes.indexOf(val) !== -1
       ? val
       : DEFAULT_TYPE
+  },
+
+  returnKeyType (val) {
+    this.node.returnKeyType = val || ''
   }
 }
 
@@ -108,6 +131,16 @@ const event = {
       return {
         value: this.node.value,
         timestamp: Date.now()
+      }
+    }
+  },
+
+  return: {
+    updator: function (obj) {
+      return {
+        attrs: {
+          value: this.node.value
+        }
       }
     }
   }

--- a/html5/render/browser/extend/components/textarea.js
+++ b/html5/render/browser/extend/components/textarea.js
@@ -1,4 +1,5 @@
 'use strict'
+import { findEnterKeyType } from '../../utils/index'
 
 const DEFAULT_ROWS = 2
 
@@ -14,7 +15,25 @@ const proto = {
     const node = document.createElement('textarea')
     node.classList.add('weex-element')
     node.classList.add('weex-textarea')
+    this.createkeyboardEvent(node)
     return node
+  },
+
+  // support enter key envent
+  createkeyboardEvent (node) {
+    if (Array.isArray(this.data.event) && this.data.event.indexOf('return') > -1) {
+      node.addEventListener('keyup', (ev) => {
+        const code = ev.keyCode
+        let key = ev.key
+        if (code === 13) {
+          if (key.toLowerCase() === 'tab') {
+            key = 'next'
+          }
+          const rightKeyType = findEnterKeyType(this.data.attr['returnKeyType'])
+          this.dispatchEvent('return', { returnKeyType: rightKeyType })
+        }
+      }, false)
+    }
   }
 }
 
@@ -34,6 +53,9 @@ const attr = {
   },
   autofocus (val) {
     this.node.autofocus = !!val
+  },
+  returnKeyType (val) {
+    this.node.returnKeyType = val || ''
   }
 }
 
@@ -67,6 +89,16 @@ const event = {
       return {
         value: this.node.value,
         timestamp: Date.now()
+      }
+    }
+  },
+
+  return: {
+    updator: function (obj) {
+      return {
+        attrs: {
+          value: this.node.value
+        }
       }
     }
   }

--- a/html5/render/browser/extend/components/textarea.js
+++ b/html5/render/browser/extend/components/textarea.js
@@ -15,12 +15,12 @@ const proto = {
     const node = document.createElement('textarea')
     node.classList.add('weex-element')
     node.classList.add('weex-textarea')
-    this.createkeyboardEvent(node)
+    this.createKeyboardEvent(node)
     return node
   },
 
   // support enter key envent
-  createkeyboardEvent (node) {
+  createKeyboardEvent (node) {
     if (Array.isArray(this.data.event) && this.data.event.indexOf('return') > -1) {
       node.addEventListener('keyup', (ev) => {
         const code = ev.keyCode

--- a/html5/render/browser/utils/index.js
+++ b/html5/render/browser/utils/index.js
@@ -213,3 +213,12 @@ export function kebabToCamel (name) {
     return `${g1.toUpperCase()}`
   })
 }
+
+export function findEnterKeyType (key) {
+  const keys = ['default', 'go', 'next', 'search', 'send']
+  if (keys.indexOf(key) > -1) {
+    return key
+  }
+  return 'done'
+}
+

--- a/html5/render/vue/components/input.js
+++ b/html5/render/vue/components/input.js
@@ -1,9 +1,13 @@
-import { base, inputCommon } from '../mixins'
+/**
+ * @fileOverview Input component.
+ * Support v-model only if vue version is large than 2.2.0
+ */
+import { inputCommon } from '../mixins'
 import { extend, mapFormEvents } from '../utils'
-import { validateStyles } from '../validator'
+// import { validateStyles } from '../validator'
 
 export default {
-  mixins: [base, inputCommon],
+  mixins: [inputCommon],
   props: {
     type: {
       type: String,
@@ -28,15 +32,24 @@ export default {
       default: false
     },
     maxlength: [String, Number],
-    retunrKeytype: String
+    returnKeyType: String
+  },
+
+  methods: {
+    focus () {
+      this.$el && this.$el.focus()
+    },
+    blur () {
+      this.$el && this.$el.blur()
+    }
   },
 
   render (createElement) {
     /* istanbul ignore next */
-    if (process.env.NODE_ENV === 'development') {
-      validateStyles('input', this.$vnode.data && this.$vnode.data.staticStyle)
-    }
-    const events = extend(this.createEventMap(), mapFormEvents(this))
+    // if (process.env.NODE_ENV === 'development') {
+    //   validateStyles('input', this.$vnode.data && this.$vnode.data.staticStyle)
+    // }
+    const events = extend(this._createEventMap(), mapFormEvents(this))
     return createElement('html:input', {
       attrs: {
         'weex-type': 'input',
@@ -48,8 +61,11 @@ export default {
         maxlength: this.maxlength,
         'returnKeyType': this.returnKeyType
       },
+      domProps: {
+        value: this.value
+      },
       on: this.createKeyboardEvent(events),
-      staticClass: 'weex-input'
+      staticClass: 'weex-input weex-el'
     })
   }
 }

--- a/html5/render/vue/components/input.js
+++ b/html5/render/vue/components/input.js
@@ -1,12 +1,9 @@
-/**
- * @fileOverview Input component.
- * Support v-model only if vue version is large than 2.2.0
- */
-
+import { base, inputCommon } from '../mixins'
 import { extend, mapFormEvents } from '../utils'
-// import { validateStyles } from '../validator'
+import { validateStyles } from '../validator'
 
 export default {
+  mixins: [base, inputCommon],
   props: {
     type: {
       type: String,
@@ -30,23 +27,16 @@ export default {
       type: [String, Boolean],
       default: false
     },
-    maxlength: [String, Number]
-  },
-
-  methods: {
-    focus () {
-      this.$el && this.$el.focus()
-    },
-    blur () {
-      this.$el && this.$el.blur()
-    }
+    maxlength: [String, Number],
+    retunrKeytype: String
   },
 
   render (createElement) {
     /* istanbul ignore next */
-    // if (process.env.NODE_ENV === 'development') {
-    //   validateStyles('input', this.$vnode.data && this.$vnode.data.staticStyle)
-    // }
+    if (process.env.NODE_ENV === 'development') {
+      validateStyles('input', this.$vnode.data && this.$vnode.data.staticStyle)
+    }
+    const events = extend(this.createEventMap(), mapFormEvents(this))
     return createElement('html:input', {
       attrs: {
         'weex-type': 'input',
@@ -55,13 +45,11 @@ export default {
         disabled: (this.disabled !== 'false' && this.disabled !== false),
         autofocus: (this.autofocus !== 'false' && this.autofocus !== false),
         placeholder: this.placeholder,
-        maxlength: this.maxlength
+        maxlength: this.maxlength,
+        'returnKeyType': this.returnKeyType
       },
-      domProps: {
-        value: this.value
-      },
-      on: extend(this._createEventMap(), mapFormEvents(this)),
-      staticClass: 'weex-input weex-el'
+      on: this.createKeyboardEvent(events),
+      staticClass: 'weex-input'
     })
   }
 }

--- a/html5/render/vue/components/textarea.js
+++ b/html5/render/vue/components/textarea.js
@@ -1,7 +1,9 @@
+import { base, inputCommon } from '../mixins'
 import { extend, mapFormEvents } from '../utils'
-// import { validateStyles } from '../validator'
+import { validateStyles } from '../validator'
 
 export default {
+  mixins: [base, inputCommon],
   props: {
     value: String,
     placeholder: String,
@@ -16,14 +18,16 @@ export default {
     rows: {
       type: [String, Number],
       default: 2
-    }
+    },
+    returnKeyType: String
   },
 
   render (createElement) {
     /* istanbul ignore next */
-    // if (process.env.NODE_ENV === 'development') {
-    //   validateStyles('textarea', this.$vnode.data && this.$vnode.data.staticStyle)
-    // }
+    if (process.env.NODE_ENV === 'development') {
+      validateStyles('textarea', this.$vnode.data && this.$vnode.data.staticStyle)
+    }
+    const events = extend(this.createEventMap(), mapFormEvents(this))
     return createElement('html:textarea', {
       attrs: {
         'weex-type': 'textarea',
@@ -31,14 +35,11 @@ export default {
         disabled: (this.disabled !== 'false' && this.disabled !== false),
         autofocus: (this.autofocus !== 'false' && this.autofocus !== false),
         placeholder: this.placeholder,
-        rows: this.rows
+        rows: this.rows,
+        'return-key-type': this.returnKeyType
       },
-      domProps: {
-        value: this.value
-      },
-      on: extend(this._createEventMap(), mapFormEvents(this)),
-      staticClass: 'weex-textarea weex-el',
-      staticStyle: this._normalizeInlineStyles(this.$vnode.data)
+      on: this.createKeyboardEvent(events),
+      staticClass: 'weex-textarea'
     }, this.value)
   }
 }

--- a/html5/render/vue/components/textarea.js
+++ b/html5/render/vue/components/textarea.js
@@ -1,9 +1,9 @@
-import { base, inputCommon } from '../mixins'
+import { inputCommon } from '../mixins'
 import { extend, mapFormEvents } from '../utils'
-import { validateStyles } from '../validator'
+// import { validateStyles } from '../validator'
 
 export default {
-  mixins: [base, inputCommon],
+  mixins: [inputCommon],
   props: {
     value: String,
     placeholder: String,
@@ -24,10 +24,10 @@ export default {
 
   render (createElement) {
     /* istanbul ignore next */
-    if (process.env.NODE_ENV === 'development') {
-      validateStyles('textarea', this.$vnode.data && this.$vnode.data.staticStyle)
-    }
-    const events = extend(this.createEventMap(), mapFormEvents(this))
+    // if (process.env.NODE_ENV === 'development') {
+    //   validateStyles('textarea', this.$vnode.data && this.$vnode.data.staticStyle)
+    // }
+    const events = extend(this._createEventMap(), mapFormEvents(this))
     return createElement('html:textarea', {
       attrs: {
         'weex-type': 'textarea',
@@ -38,8 +38,12 @@ export default {
         rows: this.rows,
         'return-key-type': this.returnKeyType
       },
+      domProps: {
+        value: this.value
+      },
       on: this.createKeyboardEvent(events),
-      staticClass: 'weex-textarea'
+      staticClass: 'weex-textarea weex-el',
+      staticStyle: this._normalizeInlineStyles(this.$vnode.data)
     }, this.value)
   }
 }

--- a/html5/render/vue/mixins/index.js
+++ b/html5/render/vue/mixins/index.js
@@ -1,9 +1,11 @@
 import base from './base'
 import style from './style'
 import scrollable from './scrollable'
+import inputCommon from './input-common'
 
 export {
   base,
+  scrollable,
   style,
-  scrollable
+  inputCommon
 }

--- a/html5/render/vue/mixins/input-common.js
+++ b/html5/render/vue/mixins/input-common.js
@@ -1,0 +1,39 @@
+// input and textare has some common api and event
+import { extend } from '../utils'
+
+const findEnterKeyType = function (key) {
+  const keys = ['default', 'go', 'next', 'search', 'send']
+  if (keys.indexOf(key) > -1) {
+    return key
+  }
+  return 'done'
+}
+
+export default {
+  methods: {
+    // support enter key envent
+    createKeyboardEvent (events) {
+      const customKeyType = this.returnKeyType
+      const self = this
+      if (this._events['return']) {
+        const keyboardEvents = {
+          'keyup': function (ev) {
+            const code = ev.keyCode
+            let key = ev.key
+            if (code === 13) {
+              if (key.toLowerCase() === 'tab') {
+                key = 'next'
+              }
+              const rightKeyType = findEnterKeyType(customKeyType)
+              ev.returnKeyType = rightKeyType
+              ev.value = ev.target.value
+              self.$emit('return', ev)
+            }
+          }
+        }
+        events = extend(events, keyboardEvents)
+      }
+      return events
+    }
+  }
+}


### PR DESCRIPTION
Input and textarea have a new attribute named `'returnKeyType` which specify your keyboard enter key type (done, next etc.)

Input and textarea have a custom event named `return`. We can get the enter key type when users press their keyboard enter key.

example
``` js
<input
        type="text"
        placeholder="search ..."
        class="input"
        autofocus="true"
        return-key-type="search"
        @return="onreturn"
      />

```
### Demo Test
+ [input](https://github.com/JackPu/incubator-weex/blob/html5-feature-input-keyboard-event/examples/component/input-demo.we)

+ [textarea vue](https://github.com/JackPu/incubator-weex/blob/html5-feature-input-keyboard-event/examples/vue/components/textarea.vue)